### PR TITLE
Converted unquoted array keys into strings (removes PHP Notices).

### DIFF
--- a/index.php
+++ b/index.php
@@ -78,19 +78,19 @@ $ghCharToDomain = array(
 	);
 
 $ghTypeToString = array(
-	extjs => 'external script',
-	injs => 'inline script block',
-	extcss => 'external stylesheet',
-	incss => 'inline style block',
-	image => 'image',
-	iframe => 'iframe'
+	'extjs' => 'external script',
+	'injs' => 'inline script block',
+	'extcss' => 'external stylesheet',
+	'incss' => 'inline style block',
+	'image' => 'image',
+	'iframe' => 'iframe'
 	);
 
 $ghTypeToSleepType = array(
-	extjs => 'js',
-	extcss => 'css',
-	image => 'gif',
-	iframe => 'html'
+	'extjs' => 'js',
+	'extcss' => 'css',
+	'image' => 'gif',
+	'iframe' => 'html'
 	);
 
 


### PR DESCRIPTION
PHP does not like array keys without quotes, but would automatically perform conversion.

I explicitly converted them to get rid of PHP Notices (when enabled)